### PR TITLE
Feat/move stop reason

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "LLM\\Tests\\": "tests/src"
+      "LLM\\Tests\\": "tests/"
     }
   },
   "config": {

--- a/src/Parsers/ChatResponseParser.php
+++ b/src/Parsers/ChatResponseParser.php
@@ -9,7 +9,6 @@ use LLM\Agents\OpenAI\Client\Exception\LimitExceededException;
 use LLM\Agents\OpenAI\Client\Exception\RateLimitException;
 use LLM\Agents\OpenAI\Client\Exception\TimeoutException;
 use LLM\Agents\OpenAI\Client\StreamChunkCallbackInterface;
-use LLM\Agents\LLM\Response\FinishReason;
 use LLM\Agents\LLM\Response\Response;
 use LLM\Agents\LLM\Response\StreamChatResponse;
 use LLM\Agents\LLM\Response\ToolCall;

--- a/src/Parsers/FinishReason.php
+++ b/src/Parsers/FinishReason.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Agents\OpenAI\Client\Parsers;
+
+enum FinishReason: string
+{
+    case Stop = 'stop';
+    case ToolCalls = 'tool_calls';
+    case Limit = 'limit';
+    case Timeout = 'timeout';
+    case Length = 'length';
+}

--- a/tests/Parsers/ChatResponseParserTest.php
+++ b/tests/Parsers/ChatResponseParserTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLM\Tests\Parsers;
+
+use ArrayIterator;
+use LLM\Agents\OpenAI\Client\Parsers\ChatResponseParser;
+use OpenAI\Contracts\ResponseStreamContract;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use ReflectionClass;
+use Traversable;
+use OpenAI\Responses\Chat\CreateStreamedResponseDelta;
+use OpenAI\Responses\Chat\CreateStreamedResponseChoice;
+use OpenAI\Responses\Chat\CreateStreamedResponse;
+
+class ChatResponseParserTest extends TestCase
+{
+    private function makeDelta(?string $content): object
+    {
+        $toolCalls = [];
+        $deltaClass = new ReflectionClass(CreateStreamedResponseDelta::class);
+        $delta = $deltaClass->newInstanceWithoutConstructor();
+        $deltaClass->getProperty('content')->setValue($delta, $content);
+        $deltaClass->getProperty('role')->setValue($delta, null);
+        $deltaClass->getProperty('toolCalls')->setValue($delta, $toolCalls);
+        return $delta;
+    }
+
+    private function makeChoice(object $delta, $finishReason = null): object
+    {
+        $choiceClass = new ReflectionClass(CreateStreamedResponseChoice::class);
+        $choice = $choiceClass->newInstanceWithoutConstructor();
+        $choiceClass->getProperty('delta')->setValue($choice, $delta);
+        $choiceClass->getProperty('finishReason')->setValue($choice, $finishReason);
+        return $choice;
+    }
+
+    private function makeChunk(array $choices): object
+    {
+        $chunkClass = new ReflectionClass(CreateStreamedResponse::class);
+        $chunk = $chunkClass->newInstanceWithoutConstructor();
+        $chunkClass->getProperty('choices')->setValue($chunk, $choices);
+        return $chunk;
+    }
+
+    private function makeStream(array $chunks): object
+    {
+        return new class($chunks) implements ResponseStreamContract {
+            private array $chunks;
+            public function __construct(array $chunks) { $this->chunks = $chunks; }
+            public function getIterator(): Traversable { return new ArrayIterator($this->chunks); }
+        };
+    }
+
+    public function test_parse_with_mock_stream_contract_returns_expected_response(): void
+    {
+        $chunk1 = $this->makeChunk([
+            $this->makeChoice($this->makeDelta('Hello, world!'))
+        ]);
+        $chunk2 = $this->makeChunk([
+            $this->makeChoice($this->makeDelta(null), 'stop')
+        ]);
+        $mockStream = $this->makeStream([$chunk1, $chunk2]);
+
+        $mockDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $parser = new ChatResponseParser($mockDispatcher);
+        $result = $parser->parse($mockStream);
+
+        $this->assertSame('Hello, world!', $result->content);
+        $this->assertSame('stop', $result->finishReason);
+    }
+}


### PR DESCRIPTION
## What was changed

- Introduced own version of the `FinishReason` enum instead of the vendor one
- Updated `ChatResponseParser`

## Why?

- To move client-specific code to the corresponding repository

## Checklist

- Closes #7
- Tested
  - [x] Tested manually
  - [x] Unit tests added